### PR TITLE
Add 'cricket bat' to slap weapons.

### DIFF
--- a/data/slaps.json
+++ b/data/slaps.json
@@ -20,6 +20,7 @@
          "cast iron skillet",
          "large trout",
          "baseball bat",
+         "cricket bat",
          "wooden cane",
          "nail",
          "printer",


### PR DESCRIPTION
Cricket bats have been shown to be effective weapons. Hence, they must be added to the bot's arsenal for punishment of lusers.