### PR TITLE
Implement wildcard permissions

### DIFF
--- a/cloudbot/permissions.py
+++ b/cloudbot/permissions.py
@@ -80,7 +80,7 @@ class PermissionManager(object):
         for user_perm, allowed_users in self.perm_users.items():
             if fnmatch(perm, user_perm):
                 for allowed_mask in allowed_users:
-                    if fnmatch(user_mask.lower(), allowed_mask):
+                    if fnmatch(allowed_mask, user_mask.lower()):
                         if notice:
                             logger.info("[{}|permissions] Allowed user {} access to {}".format(self.name, user_mask, perm))
                         return True

--- a/cloudbot/permissions.py
+++ b/cloudbot/permissions.py
@@ -75,17 +75,15 @@ class PermissionManager(object):
             if fnmatch(user_mask.lower(), backdoor.lower()):
                 return True
 
-        if not perm.lower() in self.perm_users:
-            # no one has access
-            return False
+        perm = perm.lower()
 
-        allowed_users = self.perm_users[perm.lower()]
-
-        for allowed_mask in allowed_users:
-            if fnmatch(user_mask.lower(), allowed_mask):
-                if notice:
-                    logger.info("[{}|permissions] Allowed user {} access to {}".format(self.name, user_mask, perm))
-                return True
+        for user_perm, allowed_users in self.perm_users.items():
+            if fnmatch(perm, user_perm):
+                for allowed_mask in allowed_users:
+                    if fnmatch(user_mask.lower(), allowed_mask):
+                        if notice:
+                            logger.info("[{}|permissions] Allowed user {} access to {}".format(self.name, user_mask, perm))
+                        return True
 
         return False
 


### PR DESCRIPTION
This resolves issue https://github.com/CloudBotIRC/CloudBot/issues/78

Note that, unfortunately, this causes an increase in complexity in `has_perm_mask`, due to the need to check each perm using `fnmatch`, rather than using the dict directly.