### PR TITLE
Bug fixes for default config file

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -11,7 +11,7 @@
             },
             "nick": "MyCloudBot",
             "user": "cloudbot",
-            "real_name": "CloudBot Refresh <https://github.com/CloudBotIRC/CloudBot/>",
+            "realname": "CloudBot Refresh <https://github.com/CloudBotIRC/CloudBot/>",
             "avoid_notices": false,
             "channels": [
                 "#cloudbot",

--- a/config.default.json
+++ b/config.default.json
@@ -88,7 +88,10 @@
         "blacklist": [
             "update"
         ],
-        "whitelist": []
+        "whitelist": [
+		"admin_bot", "admin_channel", "ignore", "log",
+		"core_channel","core_ctcp", "core_misc", "core_sieve", "core_tracker"
+	]
     },
     "reloading": {
         "config_reloading": true,


### PR DESCRIPTION
irc.py uses realname, not real_name. This bug resulted in the realname specified in the config not being used.

When using the default whitelist, the bot couldn't do anything including joining a channel.