### PR TITLE
Ignore cache should be reloaded after removing ignore

### DIFF
--- a/plugins/ignore.py
+++ b/plugins/ignore.py
@@ -47,7 +47,7 @@ def remove_ignore(db, conn, chan, mask):
     db.execute(table.delete().where(table.c.connection == conn).where(table.c.channel == chan)
                .where(table.c.mask == mask))
     db.commit()
-
+    load_cache(db)
 
 def is_ignored(conn, chan, mask):
     for _conn, _chan, _mask in ignore_cache:


### PR DESCRIPTION
After removing an ignored nick or mask the cache variable needs to be reloaded for the unignore to succeed.