### PR TITLE
youtube search fails to find a video if a channel is the first result…

### DIFF
--- a/plugins/youtube.py
+++ b/plugins/youtube.py
@@ -84,7 +84,7 @@ def youtube(text):
     if not dev_key:
         return "This command requires a Google Developers Console API key."
 
-    json = requests.get(search_api_url, params={"q": text, "key": dev_key}).json()
+    json = requests.get(search_api_url, params={"q": text, "key": dev_key, "type": "video"}).json()
 
     if json.get('error'):
         if json['error']['code'] == 403:
@@ -106,7 +106,7 @@ def youtime(text):
     if not dev_key:
         return "This command requires a Google Developers Console API key."
 
-    json = requests.get(search_api_url, params={"q": text, "key": dev_key}).json()
+    json = requests.get(search_api_url, params={"q": text, "key": dev_key, "type": "video"}).json()
 
     if json.get('error'):
         if json['error']['code'] == 403:


### PR DESCRIPTION
If the first search result for a query is a channel a video_Id is not returned in the json so the plugin errors out. Setting the type parameter equal to video fixes this as channels and playlists are not returned.

Example of  the issue:

    .youtube owl city


