### PR TITLE
Fixed CleverBot

### DIFF
--- a/plugins/chatbot.py
+++ b/plugins/chatbot.py
@@ -34,6 +34,8 @@ HEADERS = {
     'X-Moz': 'prefetch'
 }
 
+sess = requests.Session()
+sess.get("http://www.cleverbot.com")
 
 @hook.on_start()
 def init_vars():
@@ -52,10 +54,14 @@ def cb_think(text):
     payload = urllib.parse.urlencode(SESSION)
     digest = hashlib.md5(payload[9:35].encode('utf-8')).hexdigest()
     target_url = "{}&icognocheck={}".format(payload, digest)
-    parsed = requests.post(API_URL, data=target_url, headers=HEADERS)
+    parsed = sess.post(API_URL, data=target_url, headers=HEADERS)
     data = parsed.text.split('\r')
     SESSION['sessionid'] = data[1]
-    return html.unescape(str(data[0]))
+    if parsed.status_code == 200:
+        return html.unescape(str(data[0]))
+    else:
+	    print("CleverBot API Returned "+str(parsed.status_code))
+	    return "Error: API returned "+str(parsed.status_code)
 
 
 @hook.command("ask", "cleverbot", "cb")


### PR DESCRIPTION
Add the ability to catch non-http 200 responses such as 404 and fixed it to make it work.
It appears the API Requires cookies (such as a session key) to respond with anything other than a 404.
Fixing this was as easy as throwing a GET to the CleverBot homepage while using Requests session handling.
Then using this with the POST requests to forward cookies to the API.

TD:LR; The API expects specific cookies set by the homepage. Lack of cookies results in a 404