### PR TITLE
Implement irc capability negotiation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,7 @@ target/
 # Cloudbot
 persist/
 logs/
-config.json
+config*.json
 *.db
 *.mmdb
 *.log

--- a/cloudbot/clients/irc.py
+++ b/cloudbot/clients/irc.py
@@ -50,6 +50,7 @@ class IrcClient(Client):
     :type port: int
     :type _connected: bool
     :type _ignore_cert_errors: bool
+    :type capabilities: set[str]
     """
 
     def __init__(self, bot, name, nick, *, channels=None, config=None,
@@ -92,6 +93,8 @@ class IrcClient(Client):
         # transport and protocol
         self._transport = None
         self._protocol = None
+
+        self.capabilities = set(self.config.get('capabilities', []))
 
     def describe_server(self):
         if self.use_ssl:

--- a/config.default.json
+++ b/config.default.json
@@ -59,7 +59,12 @@
                 }
             },
             "plugins": {},
-            "command_prefix": "."
+            "command_prefix": ".",
+            "capabilities": [
+                "multi-prefix",
+                "extended-join",
+                "account-notify"
+            ]
         }
     ],
     "api_keys": {

--- a/plugins/cap.py
+++ b/plugins/cap.py
@@ -1,0 +1,82 @@
+import asyncio
+from cloudbot import hook
+from cloudbot.bot import CloudBot
+from cloudbot.clients.irc import IrcClient
+from cloudbot.event import Event
+
+
+@asyncio.coroutine
+@hook.irc_raw('004')
+def on_connect(bot, conn):
+    """
+    :type bot: CloudBot
+    :type conn: IrcClient
+    """
+
+    if not conn.capabilities:
+        return
+
+    while not conn.ready:
+        yield from asyncio.sleep(3)
+
+    m = conn.memory
+    if 'CAP_lock' not in m:
+        m['CAP_lock'] = asyncio.Lock()
+
+    with (yield from m['CAP_lock']):
+        m['CAP_LS_future'] = asyncio.Future()
+        conn.send('CAP LS')
+        server_accepts = yield from m['CAP_LS_future']
+
+        m['CAP_LIST_future'] = asyncio.Future()
+        conn.send('CAP LIST')
+        we_have = yield from m['CAP_LIST_future']
+
+        we_want = conn.capabilities
+
+        rejected = we_want - we_have - server_accepts
+        if rejected:
+            bot.logger.warning('[{}|CAP] Server rejected: {}'.format(conn.name, rejected))
+
+        missing = (we_want - we_have) & server_accepts
+        conn.send('CAP REQ :{}'.format(' '.join(missing)))
+
+        m['CAP_ACK_future'] = asyncio.Future()
+        accepted = yield from m['CAP_ACK_future']
+        if accepted is None:
+            bot.logger.warning('[{}|CAP] Failed to negotiate with the server')
+
+        if accepted:
+            bot.logger.info('[{}|CAP] Successfully negotiated for: {}'.format(conn.name, accepted))
+
+        conn.send('CAP END')
+
+
+@asyncio.coroutine
+@hook.irc_raw('CAP')
+def on_cap(conn, event):
+    """
+    :type conn: Client | IrcClient
+    :type event: Event
+    """
+
+    type = event.irc_paramlist[1].upper()
+    if type == 'LS':
+        caps = set(event.irc_paramlist[2][1:].split())
+        future = conn.memory.get('CAP_LS_future')
+        if future and not future.done():
+            future.set_result(caps)
+    elif type == 'LIST':
+        caps = set(event.irc_paramlist[2][1:].split())
+        future = conn.memory.get('CAP_LIST_future')
+        if future and not future.done():
+            future.set_result(caps)
+    elif type == 'ACK':
+        caps = set(event.irc_paramlist[2][1:].split())
+        future = conn.memory.get('CAP_ACK_future')
+        if future and not future.done():
+            future.set_result(caps)
+    elif type == 'NAK':
+        future = conn.memory.get('CAP_ACK_future')
+        if future and not future.done():
+            future.set_result(None)


### PR DESCRIPTION
Implement irc capability negotiation according to http://ircv3.net/specs/core/capability-negotiation-3.1.html


Capability negotiation (account-notify and extended-join) is a requirement for global user tracking, which may come in a later PR. Current implementation is [here](https://github.com/Abrackadabra/CloudBot/tree/tracking). You can also test it with `.show_registry <#chan>` on zerobot at #cloudbots.