### PR TITLE
Emacs vim alias

### DIFF
--- a/data/larts.txt
+++ b/data/larts.txt
@@ -39,6 +39,7 @@ pushes {user} past the Shoe Event Horizon.
 counts '1, 2, 5... er... 3!' and hurls the Holy Handgrenade Of Antioch at {user}.
 puts {user} in a nest of camel spiders.
 puts 'alias vim=emacs' in {user}'s /etc/profile.
+puts 'alias emacs=vim' in {user}'s /etc/profile.
 uninstalls every web browser from {user}'s system.
 signs {user} up for getting hit on the head lessons.
 makes {user} try to set up a Lexmark printer.


### PR DESCRIPTION
While I was on the Spigot IRC, I noticed that one of the larts in CloudBot's larts.txt was "puts 'alias vim=emacs' in {user}'s /etc/profile"
I use emacs, and this made me sad, so I added the polar opposite of that right next to it "puts 'alias emacs=vim in {user}'s /etc/profile."
