### PR TITLE
Fixed signal handling for profiling.py and exit_gracefully()

### DIFF
--- a/plugins/profiling.py
+++ b/plugins/profiling.py
@@ -113,7 +113,9 @@ def pympler_diff():
 
 # # Provide an easy way to get a threaddump, by using SIGUSR1 (only on POSIX systems)
 if os.name == "posix":
-    def debug():
+    # The handler is called with two arguments: the signal number and the current stack frame
+    # These parameters should NOT be removed
+    def debug(sig, frame):
         print(get_thread_dump())
 
     signal.signal(signal.SIGUSR1, debug)  # Register handler


### PR DESCRIPTION
This issue has existed since August 2015 (commit: 91c24fd3e7492cb6707528fb451c58fe64fcbc3c ) when the parameters of the signal handlers were mistakenly removed due to not being used inside the function. According to the [Python 3.4 docs](https://docs.python.org/3.4/library/signal.html#signal.signal) the signal handler must accept 2 parameters.